### PR TITLE
Fix L1 packet offset

### DIFF
--- a/custom_components/defa_balancer/api/client.py
+++ b/custom_components/defa_balancer/api/client.py
@@ -29,7 +29,8 @@ def parse_packet(data: bytes) -> BalancerPacket | None:
     else:
         serial = serial_raw
 
-    l1_ma = int.from_bytes(data[19:21], "little")
+    # Byte 19 is a status marker in observed packets; L1 is at 20-21.
+    l1_ma = int.from_bytes(data[20:22], "little")
     l2_ma = int.from_bytes(data[23:26], "little")
     l3_ma = int.from_bytes(data[26:29], "little")
     firmware = data[33:38].decode("ascii", errors="ignore").rstrip("\x00")

--- a/script/mock_balancer.py
+++ b/script/mock_balancer.py
@@ -57,7 +57,7 @@ DEFAULT_RATE = 2.0
 DEFAULT_FIRMWARE = "4.0.0"
 
 FIXED_14_18 = bytes.fromhex("43 9d 01 00 00")
-FIXED_21_22 = bytes.fromhex("05 00")
+FIXED_19 = 0x41
 FIXED_29 = bytes([0x02])
 FIXED_30_32 = b"D01"
 
@@ -92,8 +92,9 @@ def build_packet(
     l2_ma = max(0, min(int(l2_amp * 1000), 0xFFFFFF))
     l3_ma = max(0, min(int(l3_amp * 1000), 0xFFFFFF))
 
-    packet[19:21] = struct.pack("<H", l1_ma)
-    packet[21:23] = FIXED_21_22
+    packet[19] = FIXED_19
+    packet[20:22] = struct.pack("<H", l1_ma)
+    packet[22] = 0x00
     packet[23:26] = _encode_u24_le(l2_ma)
     packet[26:29] = _encode_u24_le(l3_ma)
     packet[29:30] = FIXED_29


### PR DESCRIPTION
## Description

Fixes an issue where L1 measurements were wrong due to reading values from wrong offset.

## Related Issue

Fixes #7 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project (run `script/lint`)
- [x] I have updated the documentation accordingly
- [X] I have updated the translations if needed

## Testing

- `check` passes
- verified L1 measurements are correct
